### PR TITLE
refactored events, updated html lib

### DIFF
--- a/bones/numeric.py
+++ b/bones/numeric.py
@@ -145,7 +145,7 @@ class ExtendedNumericSearch( html5.Div ):
 			self.appendChild( self.input2 )
 
 	def onKeyDown(self, event):
-		if html5.isReturn(event.keyCode):
+		if html5.isReturn(event):
 			self.filterChangedEvent.fire()
 
 	def updateFilter(self, filter):

--- a/bones/string.py
+++ b/bones/string.py
@@ -471,7 +471,7 @@ class ExtendedStringSearch(html5.Div):
 			self.appendChild(self.input2)
 
 	def onKeyDown(self, event):
-		if html5.isReturn(event.keyCode):
+		if html5.isReturn(event):
 			self.filterChangedEvent.fire()
 
 	def updateFilter(self, filter):

--- a/login.py
+++ b/login.py
@@ -133,7 +133,7 @@ class UserPasswordLoginHandler(BaseLoginHandler):
 		self.editform.appendChild(self.sendBtn)
 
 	def onKeyPress(self, event):
-		if event.keyCode == 13:
+		if html5.isReturn(event):
 			if html5.utils.doesEventHitWidgetOrChildren(event, self.username):
 				if self.username["value"]:
 					self.password.element.focus()

--- a/widgets/file.py
+++ b/widgets/file.py
@@ -9,7 +9,6 @@ from priorityqueue import displayDelegateSelector, moduleHandlerSelector
 from widgets.search import Search
 from widgets.tree import TreeWidget, LeafWidget
 
-
 class FileImagePopup(html5.ext.Popup):
 	def __init__(self, preview, *args, **kwargs):
 		super(FileImagePopup, self).__init__(title=preview.currentFile.get("name", translate("Unnamed Image")), className="image-viewer", *args, **kwargs)
@@ -30,7 +29,6 @@ class FileImagePopup(html5.ext.Popup):
 		btn = html5.ext.Button(translate("Close"), self.onClick)
 		btn.addClass("btn_no")
 		div.appendChild(btn)
-
 
 	def onClick(self, event):
 		self.close()

--- a/widgets/search.py
+++ b/widgets/search.py
@@ -31,7 +31,7 @@ class Search( html5.Div ):
 		self.startSearchEvent.fire( None )
 
 	def onKeyDown(self, event):
-		if html5.isReturn(event.keyCode):
+		if html5.isReturn(event):
 			self.doSearch()
 			event.preventDefault()
 			event.stopPropagation()

--- a/widgets/table.py
+++ b/widgets/table.py
@@ -199,7 +199,7 @@ class SelectTable( html5.Table ):
 			event.preventDefault()
 
 	def onKeyDown(self, event):
-		if html5.isArrowDown(event.keyCode): #Arrow down
+		if html5.isArrowDown(event): #Arrow down
 
 			if self._currentRow is None:
 				self.setCursorRow(0)
@@ -220,7 +220,7 @@ class SelectTable( html5.Table ):
 					                  removeExistingSelection=(not self._isCtlPressed))
 			event.preventDefault()
 
-		elif html5.isArrowUp(event.keyCode): #Arrow up
+		elif html5.isArrowUp(event): #Arrow up
 
 			if self._currentRow is None:
 				self.setCursorRow(0)
@@ -241,7 +241,7 @@ class SelectTable( html5.Table ):
 
 			event.preventDefault()
 
-		elif html5.isReturn(event.keyCode): # Return
+		elif html5.isReturn(event): # Return
 
 			if len( self._selectedRows )>0:
 				self.selectionActivatedEvent.fire( self, self._selectedRows )
@@ -253,7 +253,7 @@ class SelectTable( html5.Table ):
 				event.preventDefault()
 				return
 
-		elif html5.isSingleSelectionKey( event.keyCode ): #Ctrl
+		elif html5.isControl(event): #Ctrl
 			self._isCtlPressed = True
 			self._ctlStartRow = self._currentRow or 0
 
@@ -261,7 +261,7 @@ class SelectTable( html5.Table ):
 				self.addSelectedRow( self._currentRow )
 				self.setCursorRow( None, removeExistingSelection=False )
 
-		elif html5.isShift( event.keyCode ): #Shift
+		elif html5.isShift(event): #Shift
 			self._isShiftPressed = True
 			try:
 				self._ctlStartRow = self._currentRow or self._selectedRows[0] or 0
@@ -269,11 +269,11 @@ class SelectTable( html5.Table ):
 				self._ctlStartRow = 0
 
 	def onKeyUp(self, event):
-		if html5.isSingleSelectionKey( event.keyCode ):
+		if html5.isControl(event):
 			self._isCtlPressed = False
 			self._ctlStartRow = None
 
-		elif html5.isShift( event.keyCode ):
+		elif html5.isShift(event):
 			self._isShiftPressed = False
 			self._ctlStartRow = None
 
@@ -299,7 +299,7 @@ class SelectTable( html5.Table ):
 
 		self.selectionChangedEvent.fire( self, self.getCurrentSelection() )
 
-		print("Currently selected rows: %s" % str(self._selectedRows))
+		# print("Currently selected rows: %s" % str(self._selectedRows))
 
 	def removeSelectedRow(self, row):
 		"""

--- a/widgets/tree.py
+++ b/widgets/tree.py
@@ -226,15 +226,15 @@ class SelectableDiv( html5.Div ):
 		self.selectionReturnEvent.fire( self, selection )
 
 	def onKeyDown(self, event):
-		if html5.isReturn(event.keyCode): # Return
+		if html5.isReturn(event): # Return
 			self.activateCurrentSelection()
 			event.preventDefault()
 			return
-		elif html5.isSingleSelectionKey(event.keyCode): # and "multi" in (self.selectMode or ""): #Ctrl
+		elif html5.isControl(event): # and "multi" in (self.selectMode or ""): #Ctrl
 			self._isCtlPressed = True
 
 	def onKeyUp(self, event):
-		if html5.isSingleSelectionKey(event.keyCode):
+		if html5.isControl(event):
 			self._isCtlPressed = False
 
 	def clearSelection(self):

--- a/widgets/userlogoutmsg.py
+++ b/widgets/userlogoutmsg.py
@@ -10,7 +10,7 @@ class UserLogoutMsg(html5.ext.Popup):
 	checkIntervall = 1000 * 5  # We test if the system has been suspended every 5 seconds
 
 	def __init__(self, *args, **kwargs):
-		super(UserLogoutMsg, self).__init__(title=translate("Session terminated"), *args, **kwargs)
+		super(UserLogoutMsg, self).__init__(title=translate("Session terminated"), enableShortcuts=False, *args, **kwargs)
 		self.addClass("userloggedoutmsg")
 		self.isCurrentlyFailed = False
 		self.loginWindow = None


### PR DESCRIPTION
The changes of this PR refers to the PR [#4](https://github.com/viur-framework/html5/pull/4) of the html lib.

> event.keyCode is deprecated. It's recommended to use key and keyIdentifier instead.
> see: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
> 
> It's now also possible to close Popups by pressing _Escape_ You can define other keybinding by redefine the method `onDocumentKeyDown`