### PR TITLE
Merging most qualitative PyJS-based Vi into master ASAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This file documents any relevant changes done to ViUR Vi since version 2.
 
 This is the current development version.
 
+- Feature: Allow for multiple uploads in File.upload action
+
 ## [2.5.0] Vesuv
 
 Release date: Jul 26, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file documents any relevant changes done to ViUR Vi since version 2.
 
 This is the current development version.
 
+- Feature: Allow to parametrize context variable prefixes using `conf["vi.context.prefix"]`
 - Feature: Handle `frontend_default_visible`-parameter for bones also in Hierarchy handler
 - Feature: Improved structuring of `NodeWidget` and `LeafWidget` for trees
 - Feature: Allow for multiple uploads in File.upload action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file documents any relevant changes done to ViUR Vi since version 2.
 
 This is the current development version.
 
+- Feature: New "action" parameter supported in "editViews" feature
 - Feature: Allow to parametrize context variable prefixes using `conf["vi.context.prefix"]`
 - Feature: Handle `frontend_default_visible`-parameter for bones also in Hierarchy handler
 - Feature: Improved structuring of `NodeWidget` and `LeafWidget` for trees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ This file documents any relevant changes done to ViUR Vi since version 2.
 
 This is the current development version.
 
+- Feature: Handle `frontend_default_visible`-parameter for bones also in Hierarchy handler
+- Feature: Improved structuring of `NodeWidget` and `LeafWidget` for trees
 - Feature: Allow for multiple uploads in File.upload action
+- Bugfix: Tree `edit`-action should not both edit and switch parent node
 
 ## [2.5.0] Vesuv
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the current development version.
 - Feature: Improved structuring of `NodeWidget` and `LeafWidget` for trees
 - Feature: Allow for multiple uploads in File.upload action
 - Bugfix: Tree `edit`-action should not both edit and switch parent node
+- Bugfix: Escaped dash in regex for validation of `emailBone`
 
 ## [2.5.0] Vesuv
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 This file documents any relevant changes done to ViUR Vi since version 2.
 
 
-## [develop] 
-
-This is the current development version.
+## [2.5.1] Vesuv
 
 - Feature: New "action" parameter supported in "editViews" feature
 - Feature: Allow to parametrize context variable prefixes using `conf["vi.context.prefix"]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the current development version.
 - Feature: Handle `frontend_default_visible`-parameter for bones also in Hierarchy handler
 - Feature: Improved structuring of `NodeWidget` and `LeafWidget` for trees
 - Feature: Allow for multiple uploads in File.upload action
+- Bugfix: `ListInternalPreviewAction` always showed up as disabled button with no function
 - Bugfix: Tree `edit`-action should not both edit and switch parent node
 - Bugfix: Escaped dash in regex for validation of `emailBone`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Release date: Jul 26, 2019
 
 Release date: May 24, 2019
 
+- Bugfix: logics 2.4.1 with fixed unary operators
 - Bugfix: Order of path items in file module, stop path recognition when key is referenced as parentkey
 - Bugfix: Updated icons submodule
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the current development version.
 - Feature: Handle `frontend_default_visible`-parameter for bones also in Hierarchy handler
 - Feature: Improved structuring of `NodeWidget` and `LeafWidget` for trees
 - Feature: Allow for multiple uploads in File.upload action
+- Feature: Added `conf["defaultPreview"]` to set a default preview path as fallback for List-modules
 - Bugfix: `ListInternalPreviewAction` always showed up as disabled button with no function
 - Bugfix: Tree `edit`-action should not both edit and switch parent node
 - Bugfix: Escaped dash in regex for validation of `emailBone`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the current development version.
 - Feature: Allow for multiple uploads in File.upload action
 - Bugfix: Tree `edit`-action should not both edit and switch parent node
 - Bugfix: Escaped dash in regex for validation of `emailBone`
+- Bugfix: `treeDirBone` fixed
 
 ## [2.5.0] Vesuv
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the current development version.
 - Feature: Handle `frontend_default_visible`-parameter for bones also in Hierarchy handler
 - Feature: Improved structuring of `NodeWidget` and `LeafWidget` for trees
 - Feature: Allow for multiple uploads in File.upload action
+- Feature: Added `conf["defaultPreview"]` to set a default preview path as fallback for List-modules
+- Bugfix: `ListInternalPreviewAction` always showed up as disabled button with no function
 - Bugfix: Tree `edit`-action should not both edit and switch parent node
 - Bugfix: Escaped dash in regex for validation of `emailBone`
 - Bugfix: `treeDirBone` fixed
@@ -33,6 +35,7 @@ Release date: Jul 26, 2019
 
 Release date: May 24, 2019
 
+- Bugfix: logics 2.4.1 with fixed unary operators
 - Bugfix: Order of path items in file module, stop path recognition when key is referenced as parentkey
 - Bugfix: Updated icons submodule
 

--- a/actions/context.py
+++ b/actions/context.py
@@ -87,7 +87,7 @@ class ContextAction(html5.ext.Button):
 
 		# Generate title
 		if title is None:
-			for key in ["name", "title"]:
+			for key in conf["vi.context.title.bones"]:
 				title = data.get(key)
 
 				if title:

--- a/actions/file.py
+++ b/actions/file.py
@@ -17,12 +17,14 @@ class FileSelectUploader(html5.Input):
 	def __init__(self, *args, **kwargs):
 		super( FileSelectUploader, self ).__init__( *args, **kwargs )
 		self["type"] = "file"
+		self["multiple"] = True
 		self["style"]["display"] = "none"
 		self.sinkEvent("onChange")
 
 	def onChange(self, event):
 		if event.target.files.length > 0:
-			Uploader(event.target.files.item(0), self.parent().node)
+			for i in range(event.target.files.length):
+				Uploader(event.target.files.item(i), self.parent().node)
 
 		self.parent().removeChild( self )
 

--- a/actions/list.py
+++ b/actions/list.py
@@ -245,13 +245,14 @@ class ListPreviewAction(html5.Span):
 	def __init__(self, module, handler, actionName, *args, **kwargs ):
 		super(ListPreviewAction, self ).__init__(*args, **kwargs)
 
+		self.urls = conf["defaultPreview"]
+
 		self.urlCb = html5.Select()
 		self.appendChild(self.urlCb)
 
 		btn = html5.ext.Button(translate("Preview"), callback=self.onClick)
 		btn["class"] = "icon preview"
 		self.appendChild(btn)
-		self.urls = None
 
 		self["disabled"] = True
 		self.isDisabled = True
@@ -287,9 +288,12 @@ class ListPreviewAction(html5.Span):
 		if module in conf["modules"].keys():
 			moduleConfig = conf["modules"][module]
 
-			self.urls = moduleConfig.get("preview", moduleConfig.get("previewurls"))
-			if self.urls:
-				self.rebuildCB()
+			urls = moduleConfig.get("preview", moduleConfig.get("previewurls"))
+			if urls:
+				self.urls = urls
+
+		if self.urls:
+			self.rebuildCB()
 
 	def onDetach(self):
 		self.parent().parent().selectionChangedEvent.unregister(self)
@@ -307,7 +311,7 @@ class ListPreviewAction(html5.Span):
 				self.isDisabled = True
 
 	def onClick(self, sender=None):
-		if self.urls is None:
+		if not self.urls:
 			return
 
 		selection = self.parent().parent().getCurrentSelection()
@@ -346,7 +350,7 @@ class ListPreviewAction(html5.Span):
 		correctHandler = handler == "list" or handler.startswith("list.")
 		hasAccess = conf["currentUser"] and ("root" in conf["currentUser"]["access"] or module+"-view" in conf["currentUser"]["access"])
 		isDisabled = "disabledFunctions" in modConf and modConf["disabledFunctions"] and "view" in conf["modules"][module]["disabledFunctions"]
-		isAvailable = bool(modConf.get("preview", modConf.get("previewurls")))
+		isAvailable = bool(modConf.get("preview", modConf.get("previewurls", conf["defaultPreview"])))
 
 		return correctAction and correctHandler and hasAccess and not isDisabled and isAvailable
 
@@ -591,7 +595,6 @@ class ListSelectFilterAction( html5.ext.Button ):
 	def __init__(self, *args, **kwargs ):
 		super( ListSelectFilterAction, self ).__init__( translate("Select Filter"), *args, **kwargs )
 		self["class"] = "icon selectfilter"
-		self.urls = None
 		self.filterSelector = None
 
 	def onAttach(self):

--- a/actions/tree.py
+++ b/actions/tree.py
@@ -7,207 +7,211 @@ from priorityqueue import actionDelegateSelector
 from widgets.edit import EditWidget
 
 
-class AddLeafAction( html5.ext.Button ):
+class AddLeafAction(html5.ext.Button):
 	"""
 		Creates a new leaf (ie. a file) for a tree application
 	"""
+
 	def __init__(self, *args, **kwargs):
-		super( AddLeafAction, self ).__init__( translate("Add"), *args, **kwargs )
+		super(AddLeafAction, self).__init__(translate("Add"), *args, **kwargs)
 		self["class"] = "icon add leaf"
 
 	@staticmethod
-	def isSuitableFor( module, handler, actionName ):
+	def isSuitableFor(module, handler, actionName):
 		if module is None or module not in conf["modules"].keys():
 			return False
 
-		correctAction = actionName=="add.leaf"
+		correctAction = actionName == "add.leaf"
 		correctHandler = handler == "tree" or handler.startswith("tree.")
-		hasAccess = conf["currentUser"] and ("root" in conf["currentUser"]["access"] or module+"-add" in conf["currentUser"]["access"])
-		isDisabled = module is not None and "disabledFunctions" in conf["modules"][module].keys() and conf["modules"][module]["disabledFunctions"] and "add-leaf" in conf["modules"][module]["disabledFunctions"]
+		hasAccess = conf["currentUser"] and (
+					"root" in conf["currentUser"]["access"] or module + "-add" in conf["currentUser"]["access"])
+		isDisabled = module is not None and "disabledFunctions" in conf["modules"][module].keys() and \
+		             conf["modules"][module]["disabledFunctions"] and "add-leaf" in conf["modules"][module][
+			             "disabledFunctions"]
 
 		return correctAction and correctHandler and hasAccess and not isDisabled
 
 	def onClick(self, sender=None):
-		pane = Pane("Add", closeable=True, iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_add_leaf"])
+		pane = Pane("Add", closeable=True,
+		            iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_add_leaf"])
 		conf["mainWindow"].stackPane(pane)
-		edwg = EditWidget( self.parent().parent().module, EditWidget.appTree, node=self.parent().parent().node, skelType="leaf" )
-		pane.addWidget( edwg )
+		edwg = EditWidget(self.parent().parent().module, EditWidget.appTree, node=self.parent().parent().node,
+		                  skelType="leaf")
+		pane.addWidget(edwg)
 		pane.focus()
 
 	def resetLoadingState(self):
 		pass
 
-actionDelegateSelector.insert( 1, AddLeafAction.isSuitableFor, AddLeafAction )
+
+actionDelegateSelector.insert(1, AddLeafAction.isSuitableFor, AddLeafAction)
 
 
-class AddNodeAction( html5.ext.Button ):
+class AddNodeAction(html5.ext.Button):
 	"""
 		Creates a new node (ie. a directory) for a tree application
 	"""
+
 	def __init__(self, *args, **kwargs):
-		super( AddNodeAction, self ).__init__(  translate("Add"), *args, **kwargs )
+		super(AddNodeAction, self).__init__(translate("Add"), *args, **kwargs)
 		self["class"] = "icon add node"
 
 	@staticmethod
-	def isSuitableFor( module, handler, actionName ):
+	def isSuitableFor(module, handler, actionName):
 		if module is None or module not in conf["modules"].keys():
 			return False
 
-		correctAction = actionName=="add.node"
+		correctAction = actionName == "add.node"
 		correctHandler = handler == "tree" or handler.startswith("tree.")
-		hasAccess = conf["currentUser"] and ("root" in conf["currentUser"]["access"] or module+"-add" in conf["currentUser"]["access"])
-		isDisabled = module is not None and "disabledFunctions" in conf["modules"][module].keys() and conf["modules"][module]["disabledFunctions"] and "add-node" in conf["modules"][module]["disabledFunctions"]
+		hasAccess = conf["currentUser"] and (
+					"root" in conf["currentUser"]["access"] or module + "-add" in conf["currentUser"]["access"])
+		isDisabled = module is not None and "disabledFunctions" in conf["modules"][module].keys() and \
+		             conf["modules"][module]["disabledFunctions"] and "add-node" in conf["modules"][module][
+			             "disabledFunctions"]
 
-		return  correctAction and correctHandler and hasAccess and not isDisabled
+		return correctAction and correctHandler and hasAccess and not isDisabled
 
 	def onClick(self, sender=None):
-		pane = Pane( translate("Add"), closeable=True, iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_add_node" ])
-		conf["mainWindow"].stackPane( pane )
-		edwg = EditWidget( self.parent().parent().module, EditWidget.appTree, node=self.parent().parent().node, skelType="node" )
-		pane.addWidget( edwg )
+		pane = Pane(translate("Add"), closeable=True,
+		            iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_add_node"])
+		conf["mainWindow"].stackPane(pane)
+		edwg = EditWidget(self.parent().parent().module, EditWidget.appTree, node=self.parent().parent().node,
+		                  skelType="node")
+		pane.addWidget(edwg)
 		pane.focus()
 
 	def resetLoadingState(self):
 		pass
 
-actionDelegateSelector.insert( 1, AddNodeAction.isSuitableFor, AddNodeAction )
+
+actionDelegateSelector.insert(1, AddNodeAction.isSuitableFor, AddNodeAction)
 
 
-class EditAction( html5.ext.Button ):
+class EditAction(html5.ext.Button):
 	"""
 		Edits an entry inside a tree application.
 		The type (node or leaf) of the entry is determined dynamically
 	"""
+
 	def __init__(self, *args, **kwargs):
-		super( EditAction, self ).__init__(  translate("Edit"), *args, **kwargs )
+		super(EditAction, self).__init__(translate("Edit"), *args, **kwargs)
 		self["class"] = "icon edit"
-		self["disabled"]= True
-		self.isDisabled=True
+		self["disabled"] = True
+		self.isDisabled = True
 
 	def onAttach(self):
-		super(EditAction,self).onAttach()
-		self.parent().parent().selectionChangedEvent.register( self )
-		self.parent().parent().selectionActivatedEvent.register( self )
+		super(EditAction, self).onAttach()
+		self.parent().parent().selectionChangedEvent.register(self)
+		self.parent().parent().selectionActivatedEvent.register(self)
 
 	def onDetach(self):
-		self.parent().parent().selectionChangedEvent.unregister( self )
-		self.parent().parent().selectionActivatedEvent.unregister( self )
-		super(EditAction,self).onDetach()
+		self.parent().parent().selectionChangedEvent.unregister(self)
+		self.parent().parent().selectionActivatedEvent.unregister(self)
+		super(EditAction, self).onDetach()
 
-	def onSelectionActivated(self, table, selection ):
+	def onSelectionActivated(self, table, selection):
 		if (not self.parent().parent().selectMode
-			and len(selection) == 1
-			and isinstance(selection[0], self.parent().parent().leafWidget)):
+				and len(selection) == 1
+				and selection[0].skelType == "leaf"):
 
-			pane = Pane(
-				translate("Edit"),
-				closeable=True,
-				iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_edit"]
-			)
-			conf["mainWindow"].stackPane(pane)
+			self.edit([selection[0]])
 
-			if isinstance( selection[0], self.parent().parent().nodeWidget):
-				skelType = "node"
+	def onSelectionChanged(self, table, selection):
+		if len(selection) > 0:
+			if self.isDisabled:
+				self.isDisabled = False
+			self["disabled"] = False
+		else:
+			if not self.isDisabled:
+				self["disabled"] = True
+				self.isDisabled = True
 
-			elif isinstance( selection[0], self.parent().parent().leafWidget):
-				skelType = "leaf"
+	@staticmethod
+	def isSuitableFor(module, handler, actionName):
+		if module is None or module not in conf["modules"].keys():
+			return False
 
-			else:
-				raise ValueError("Unknown selection type: %s" % str(type(selection[0])))
+		correctAction = actionName == "edit"
+		correctHandler = handler == "tree" or handler.startswith("tree.")
+		hasAccess = conf["currentUser"] and (
+					"root" in conf["currentUser"]["access"] or module + "-edit" in conf["currentUser"]["access"])
+		isDisabled = module is not None and "disabledFunctions" in conf["modules"][module].keys() and \
+		             conf["modules"][module]["disabledFunctions"] and "edit" in conf["modules"][module][
+			             "disabledFunctions"]
+		return correctAction and correctHandler and hasAccess and not isDisabled
+
+	def onClick(self, sender=None):
+		selection = self.parent().parent().getCurrentSelection()
+		if not selection:
+			return
+
+		self.edit(selection)
+
+	def edit(self, selection):
+		for s in selection:
+			pane = Pane(translate("Edit"), closeable=True)
+			conf["mainWindow"].stackPane(pane, focus=True)
+
+			print(s)
+			print(s.skelType)
 
 			edwg = EditWidget(
 				self.parent().parent().module,
 				EditWidget.appTree,
-				key=selection[0].data["key"],
-				skelType=skelType
-			)
+				key=s.data["key"],
+				skelType=s.skelType,
+			    iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_edit"])
 			pane.addWidget(edwg)
-			pane.focus()
-
-	def onSelectionChanged(self, table, selection ):
-		if len(selection)>0:
-			if self.isDisabled:
-				self.isDisabled = False
-			self["disabled"]= False
-		else:
-			if not self.isDisabled:
-				self["disabled"]= True
-				self.isDisabled = True
-
-	@staticmethod
-	def isSuitableFor( module, handler, actionName ):
-		if module is None or module not in conf["modules"].keys():
-			return False
-
-		correctAction = actionName=="edit"
-		correctHandler = handler == "tree" or handler.startswith("tree.")
-		hasAccess = conf["currentUser"] and ("root" in conf["currentUser"]["access"] or module+"-edit" in conf["currentUser"]["access"])
-		isDisabled = module is not None and "disabledFunctions" in conf["modules"][module].keys() and conf["modules"][module]["disabledFunctions"] and "edit" in conf["modules"][module]["disabledFunctions"]
-		return correctAction and correctHandler and hasAccess and not isDisabled
-
-	def onClick(self, sender=None):
-		selection = self.parent().parent().getCurrentSelection()
-		if not selection:
-			return
-		print(selection)
-		for s in selection:
-			pane = Pane(translate("Edit"), closeable=True)
-			conf["mainWindow"].stackPane( pane, focus=True )
-			if isinstance(s,self.parent().parent().nodeWidget):
-				skelType = "node"
-			elif isinstance(s,self.parent().parent().leafWidget):
-				skelType = "leaf"
-			else:
-				raise ValueError("Unknown selection type: %s" % str(type(s)))
-			edwg = EditWidget( self.parent().parent().module, EditWidget.appTree, key=s.data["key"], skelType=skelType, iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_edit" ])
-			pane.addWidget( edwg )
 
 	def resetLoadingState(self):
 		pass
 
-actionDelegateSelector.insert( 1, EditAction.isSuitableFor, EditAction )
+
+actionDelegateSelector.insert(1, EditAction.isSuitableFor, EditAction)
 
 
-class DeleteAction( html5.ext.Button ):
+class DeleteAction(html5.ext.Button):
 	"""
 		Allows deleting an entry in a tree-module.
 		The type (node or leaf) of the entry is determined dynamically.
 	"""
-	def __init__(self, *args, **kwargs):
-		super( DeleteAction, self ).__init__(  translate("Delete"), *args, **kwargs )
-		self["class"] = "icon delete"
-		self["disabled"]= True
-		self.isDisabled=True
 
+	def __init__(self, *args, **kwargs):
+		super(DeleteAction, self).__init__(translate("Delete"), *args, **kwargs)
+		self["class"] = "icon delete"
+		self["disabled"] = True
+		self.isDisabled = True
 
 	def onAttach(self):
-		super(DeleteAction,self).onAttach()
-		self.parent().parent().selectionChangedEvent.register( self )
+		super(DeleteAction, self).onAttach()
+		self.parent().parent().selectionChangedEvent.register(self)
 
 	def onDetach(self):
-		self.parent().parent().selectionChangedEvent.unregister( self )
-		super(DeleteAction,self).onDetach()
+		self.parent().parent().selectionChangedEvent.unregister(self)
+		super(DeleteAction, self).onDetach()
 
-	def onSelectionChanged(self, table, selection ):
-		if len(selection)>0:
+	def onSelectionChanged(self, table, selection):
+		if len(selection) > 0:
 			if self.isDisabled:
 				self.isDisabled = False
-			self["disabled"]= False
+			self["disabled"] = False
 		else:
 			if not self.isDisabled:
-				self["disabled"]= True
+				self["disabled"] = True
 				self.isDisabled = True
 
-
 	@staticmethod
-	def isSuitableFor( module, handler, actionName ):
+	def isSuitableFor(module, handler, actionName):
 		if module is None or module not in conf["modules"].keys():
 			return False
 
-		correctAction = actionName=="delete"
+		correctAction = actionName == "delete"
 		correctHandler = handler == "tree" or handler.startswith("tree.")
-		hasAccess = conf["currentUser"] and ("root" in conf["currentUser"]["access"] or module+"-delete" in conf["currentUser"]["access"])
-		isDisabled = module is not None and "disabledFunctions" in conf["modules"][module].keys() and conf["modules"][module]["disabledFunctions"] and "delete" in conf["modules"][module]["disabledFunctions"]
+		hasAccess = conf["currentUser"] and (
+					"root" in conf["currentUser"]["access"] or module + "-delete" in conf["currentUser"]["access"])
+		isDisabled = module is not None and "disabledFunctions" in conf["modules"][module].keys() and \
+		             conf["modules"][module]["disabledFunctions"] and "delete" in conf["modules"][module][
+			             "disabledFunctions"]
 
 		return correctAction and correctHandler and hasAccess and not isDisabled
 
@@ -215,71 +219,80 @@ class DeleteAction( html5.ext.Button ):
 		selection = self.parent().parent().getCurrentSelection()
 		if not selection:
 			return
-		d = html5.ext.YesNoDialog(translate("Delete {amt} Entries?",amt=len(selection)) ,title=translate("Delete them?"), yesCallback=self.doDelete, yesLabel=translate("Delete"), noLabel=translate("Keep") )
+		d = html5.ext.YesNoDialog(translate("Delete {amt} Entries?", amt=len(selection)),
+		                          title=translate("Delete them?"), yesCallback=self.doDelete,
+		                          yesLabel=translate("Delete"), noLabel=translate("Keep"))
 		d.deleteList = selection
-		d["class"].append( "delete" )
+		d["class"].append("delete")
 
 	def doDelete(self, dialog):
 		deleteList = dialog.deleteList
 		for x in deleteList:
-			if isinstance(x,self.parent().parent().nodeWidget ):
-				NetworkService.request( self.parent().parent().module, "delete/node", {"key": x.data["key"]}, secure=True, modifies=True )
-			elif isinstance(x,self.parent().parent().leafWidget ):
-				NetworkService.request( self.parent().parent().module, "delete/leaf", {"key": x.data["key"]}, secure=True, modifies=True )
+			if isinstance(x, self.parent().parent().nodeWidget):
+				NetworkService.request(self.parent().parent().module, "delete/node", {"key": x.data["key"]},
+				                       secure=True, modifies=True)
+			elif isinstance(x, self.parent().parent().leafWidget):
+				NetworkService.request(self.parent().parent().module, "delete/leaf", {"key": x.data["key"]},
+				                       secure=True, modifies=True)
 
 	def resetLoadingState(self):
 		pass
 
-actionDelegateSelector.insert( 1, DeleteAction.isSuitableFor, DeleteAction )
 
-class ReloadAction( html5.ext.Button ):
+actionDelegateSelector.insert(1, DeleteAction.isSuitableFor, DeleteAction)
+
+
+class ReloadAction(html5.ext.Button):
 	"""
 		Allows adding an entry in a list-module.
 	"""
+
 	def __init__(self, *args, **kwargs):
-		super( ReloadAction, self ).__init__( translate("Reload"), *args, **kwargs )
+		super(ReloadAction, self).__init__(translate("Reload"), *args, **kwargs)
 		self["class"] = "icon reload"
 
 	@staticmethod
-	def isSuitableFor( module, handler, actionName ):
-		return actionName=="reload" and (handler == "tree" or handler.startswith("tree."))
+	def isSuitableFor(module, handler, actionName):
+		return actionName == "reload" and (handler == "tree" or handler.startswith("tree."))
 
 	def onClick(self, sender=None):
 		self["class"].append("is_loading")
-		NetworkService.notifyChange( self.parent().parent().module )
+		NetworkService.notifyChange(self.parent().parent().module)
 
 	def resetLoadingState(self):
 		if "is_loading" in self["class"]:
 			self["class"].remove("is_loading")
 
-actionDelegateSelector.insert( 1, ReloadAction.isSuitableFor, ReloadAction )
+
+actionDelegateSelector.insert(1, ReloadAction.isSuitableFor, ReloadAction)
 
 
-class SelectRootNode( html5.Select ):
+class SelectRootNode(html5.Select):
 	"""
 		Allows selecting a different rootNode in Tree applications
 	"""
+
 	def __init__(self, module, handler, actionName, *args, **kwargs):
-		super( SelectRootNode, self ).__init__( *args, **kwargs )
+		super(SelectRootNode, self).__init__(*args, **kwargs)
 		self.sinkEvent("onChange")
 		self.hide()
 
 	def onAttach(self):
-		super( SelectRootNode, self ).onAttach()
-		self.parent().parent().rootNodeChangedEvent.register( self )
+		super(SelectRootNode, self).onAttach()
+		self.parent().parent().rootNodeChangedEvent.register(self)
 
 		if self.parent().parent().rootNode is None:
 			self.update()
 
 	def onDetach(self):
-		self.parent().parent().rootNodeChangedEvent.unregister( self )
-		super( SelectRootNode, self ).onDetach()
+		self.parent().parent().rootNodeChangedEvent.unregister(self)
+		super(SelectRootNode, self).onDetach()
 
 	def update(self):
 		self.removeAllChildren()
-		NetworkService.request( self.parent().parent().module, "listRootNodes",
-		                            successHandler=self.onRootNodesAvailable,
-		                                cacheable=True )
+		NetworkService.request(self.parent().parent().module, "listRootNodes",
+		                       successHandler=self.onRootNodesAvailable,
+		                       cacheable=True)
 
 	def onRootNodeChanged(self, newNode):
 		for option in self._children:
@@ -288,14 +301,14 @@ class SelectRootNode( html5.Select ):
 				return
 
 	def onRootNodesAvailable(self, req):
-		res = NetworkService.decode( req )
+		res = NetworkService.decode(req)
 		for node in res:
 			option = html5.Option()
 			option["value"] = node["key"]
-			option.appendChild( html5.TextNode( node[ "name"] ) )
+			option.appendChild(html5.TextNode(node["name"]))
 			if node["key"] == self.parent().parent().rootNode:
 				option["selected"] = True
-			self.appendChild( option )
+			self.appendChild(option)
 
 		if len(self.children()) > 1:
 			self.show()
@@ -304,30 +317,33 @@ class SelectRootNode( html5.Select ):
 
 	def onChange(self, event):
 		newRootNode = self["options"].item(self["selectedIndex"]).value
-		self.parent().parent().setRootNode( newRootNode )
+		self.parent().parent().setRootNode(newRootNode)
 
 	@staticmethod
-	def isSuitableFor( module, handler, actionName ):
-		return actionName=="selectrootnode" and (handler == "tree" or handler.startswith("tree."))
-
-actionDelegateSelector.insert( 1, SelectRootNode.isSuitableFor, SelectRootNode )
+	def isSuitableFor(module, handler, actionName):
+		return actionName == "selectrootnode" and (handler == "tree" or handler.startswith("tree."))
 
 
-class ReturnSelectionAction( html5.ext.Button ):
+actionDelegateSelector.insert(1, SelectRootNode.isSuitableFor, SelectRootNode)
+
+
+class ReturnSelectionAction(html5.ext.Button):
 	"""
 		This is the new "activateSelectionAction" for Trees - we need a different event
 		to avoid conflicts with "open that folder" action.
 	"""
-	def __init__(self, *args, **kwargs ):
-		super( ReturnSelectionAction, self ).__init__( translate("Select"), *args, **kwargs )
+
+	def __init__(self, *args, **kwargs):
+		super(ReturnSelectionAction, self).__init__(translate("Select"), *args, **kwargs)
 		self["class"] = "icon activateselection"
 
 	def onClick(self, sender=None):
 		self.parent().parent().returnCurrentSelection()
 
 	@staticmethod
-	def isSuitableFor( module, handler, actionName ):
+	def isSuitableFor(module, handler, actionName):
 		correctHandler = handler == "tree" or handler.startswith("tree.")
-		return( actionName=="select" and  correctHandler)
+		return (actionName == "select" and correctHandler)
 
-actionDelegateSelector.insert( 3, ReturnSelectionAction.isSuitableFor, ReturnSelectionAction )
+
+actionDelegateSelector.insert(3, ReturnSelectionAction.isSuitableFor, ReturnSelectionAction)

--- a/actions/tree.py
+++ b/actions/tree.py
@@ -310,7 +310,7 @@ class SelectRootNode(html5.Select):
 				option["selected"] = True
 			self.appendChild(option)
 
-		if len(self.children()) > 1:
+		if len(self.children()) > 1 and not self.parent().parent().context:
 			self.show()
 		else:
 			self.hide()

--- a/actions/tree.py
+++ b/actions/tree.py
@@ -28,8 +28,8 @@ class AddLeafAction( html5.ext.Button ):
 		return correctAction and correctHandler and hasAccess and not isDisabled
 
 	def onClick(self, sender=None):
-		pane = Pane("Add", closeable=True)
-		conf["mainWindow"].stackPane( pane, iconClasses=["modul_%s" % self.parent().parent().module, "apptype_tree", "action_add_leaf" ] )
+		pane = Pane("Add", closeable=True, iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_add_leaf"])
+		conf["mainWindow"].stackPane(pane)
 		edwg = EditWidget( self.parent().parent().module, EditWidget.appTree, node=self.parent().parent().node, skelType="leaf" )
 		pane.addWidget( edwg )
 		pane.focus()
@@ -61,7 +61,7 @@ class AddNodeAction( html5.ext.Button ):
 		return  correctAction and correctHandler and hasAccess and not isDisabled
 
 	def onClick(self, sender=None):
-		pane = Pane( translate("Add"), closeable=True, iconClasses=["modul_%s" % self.parent().parent().module, "apptype_tree", "action_add_node" ])
+		pane = Pane( translate("Add"), closeable=True, iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_add_node" ])
 		conf["mainWindow"].stackPane( pane )
 		edwg = EditWidget( self.parent().parent().module, EditWidget.appTree, node=self.parent().parent().node, skelType="node" )
 		pane.addWidget( edwg )
@@ -96,7 +96,7 @@ class EditAction( html5.ext.Button ):
 
 	def onSelectionActivated(self, table, selection ):
 		if not self.parent().parent().selectMode and len(selection)==1:
-			pane = Pane( translate("Edit"), closeable=True, iconClasses=["modul_%s" % self.parent().parent().module, "apptype_tree", "action_edit" ])
+			pane = Pane( translate("Edit"), closeable=True, iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_edit" ])
 			conf["mainWindow"].stackPane( pane )
 			if isinstance( selection[0], self.parent().parent().nodeWidget):
 				skelType = "node"
@@ -143,7 +143,7 @@ class EditAction( html5.ext.Button ):
 				skelType = "leaf"
 			else:
 				raise ValueError("Unknown selection type: %s" % str(type(s)))
-			edwg = EditWidget( self.parent().parent().module, EditWidget.appTree, key=s.data["key"], skelType=skelType, iconClasses=["modul_%s" % self.parent().parent().module, "apptype_tree", "action_edit" ])
+			edwg = EditWidget( self.parent().parent().module, EditWidget.appTree, key=s.data["key"], skelType=skelType, iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_edit" ])
 			pane.addWidget( edwg )
 
 	def resetLoadingState(self):

--- a/actions/tree.py
+++ b/actions/tree.py
@@ -95,17 +95,33 @@ class EditAction( html5.ext.Button ):
 		super(EditAction,self).onDetach()
 
 	def onSelectionActivated(self, table, selection ):
-		if not self.parent().parent().selectMode and len(selection)==1:
-			pane = Pane( translate("Edit"), closeable=True, iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_edit" ])
-			conf["mainWindow"].stackPane( pane )
+		if (not self.parent().parent().selectMode
+			and len(selection) == 1
+			and isinstance(selection[0], self.parent().parent().leafWidget)):
+
+			pane = Pane(
+				translate("Edit"),
+				closeable=True,
+				iconClasses=["module_%s" % self.parent().parent().module, "apptype_tree", "action_edit"]
+			)
+			conf["mainWindow"].stackPane(pane)
+
 			if isinstance( selection[0], self.parent().parent().nodeWidget):
 				skelType = "node"
+
 			elif isinstance( selection[0], self.parent().parent().leafWidget):
 				skelType = "leaf"
+
 			else:
 				raise ValueError("Unknown selection type: %s" % str(type(selection[0])))
-			edwg = EditWidget( self.parent().parent().module, EditWidget.appTree, key=selection[0].data["key"], skelType=skelType)
-			pane.addWidget( edwg )
+
+			edwg = EditWidget(
+				self.parent().parent().module,
+				EditWidget.appTree,
+				key=selection[0].data["key"],
+				skelType=skelType
+			)
+			pane.addWidget(edwg)
 			pane.focus()
 
 	def onSelectionChanged(self, table, selection ):

--- a/actions/tree_simple.py
+++ b/actions/tree_simple.py
@@ -43,12 +43,32 @@ class AddNodeAction( html5.ext.Button ):
 	def createDir(self, dialog, dirName ):
 		if len(dirName)==0:
 			return
-		r = NetworkService.request(self.parent().parent().module,"add/node",{"node": self.parent().parent().node,"name":dirName}, secure=True, modifies=True, successHandler=self.onMkDir)
+		r = NetworkService.request(
+			self.parent().parent().module, "add/node",
+			params={
+				"node": self.parent().parent().node,
+			 	"name": dirName},
+			secure=True,
+			modifies=True,
+			successHandler=self.onMkDir,
+			failureHandler=self.onError
+		)
+
 		r.dirName = dirName
 
 	def onMkDir(self, req):
 		dirName = req.dirName
 		conf["mainWindow"].log("success",translate("Directory \"{name}\" created.",name=dirName))
+
+	def onError(self, req, code):
+		dirName = req.dirName
+		conf["mainWindow"].log(
+			"error",
+			translate(
+				"Directory \"{name}\" cannot be created, error {code}.",
+				name=dirName, code=code
+			)
+		)
 
 	def resetLoadingState(self):
 		pass

--- a/admin.py
+++ b/admin.py
@@ -167,18 +167,22 @@ class AdminScreen(Screen):
 		sortedModules = []
 		topLevelModules = {}
 
-		for x, y in config["modules"].items():
-			sortedModules.append((x, y))
+		for module, info in config["modules"].items():
+			if not "root" in userAccess and not any([x.startswith(module) for x in userAccess]):
+				# Skip this module, as the user couldn't interact with it anyway
+				continue
 
-			groupName = y["name"].split(":")[0] + ": "
+			sortedModules.append((module, info))
+
+			groupName = info["name"].split(":")[0] + ": "
 
 			if groupName not in groupPanes.keys():
-				topLevelModules.update({x: y})
+				topLevelModules.update({module: info})
 			else:
-				if path and x == path[0]:
+				if path and module == path[0]:
 					currentActiveGroup = groupName
 
-				groupedModules[groupName].append((x, y))
+				groupedModules[groupName].append((module, info))
 
 		conf["vi.groupedModules"] = groupedModules
 
@@ -186,28 +190,20 @@ class AdminScreen(Screen):
 
 		# When create module panes
 		for module, info in sortedModules:
-			if not "root" in userAccess and not any([x.startswith(module) for x in userAccess]):
-				# Skip this module, as the user couldn't interact with it anyway
-				continue
-			info.update({"_handler":handler})
-
-			conf["modules"][module] = info
-
-			if "views" in conf["modules"][module].keys() and conf["modules"][module]["views"]:
-				for v in conf["modules"][module]["views"]:  # Work-a-round for PyJS not supporting id()
+			if "views" in info.keys() and info["views"]:
+				for v in info["views"]:  # Work-a-round for PyJS not supporting id()
 					v["__id"] = predefinedFilterCounter
 					predefinedFilterCounter += 1
-
 
 			if currentActiveGroup or module in topLevelModules:
 				handlerCls = HandlerClassSelector.select(module, info)
 				assert handlerCls is not None, "No handler available for module '%s'" % module
 
-				conf["modules"][module]["visibleName"] = conf["modules"][module]["name"]
+				info["visibleName"] = info["name"]
 				handler = None
 
 				if info["name"] and currentActiveGroup and info["name"].startswith(currentActiveGroup):
-					conf["modules"][module]["visibleName"] = conf["modules"][module]["name"].replace(currentActiveGroup, "")
+					info["visibleName"] = info["name"].replace(currentActiveGroup, "")
 					handler = handlerCls(module, info)
 					groupPanes[currentActiveGroup].addChildPane(handler)
 
@@ -215,7 +211,11 @@ class AdminScreen(Screen):
 					handler = handlerCls(module, info)
 					panes.append((info["visibleName"], info.get("sortIndex"), handler))
 
-		# Sorting our top level entries
+				info["_handler"] = handler
+
+			conf["modules"][module] = info
+
+	# Sorting our top level entries
 		panes.sort(key=lambda entry: "%d-%010d-%s" % (1 if entry[1] is None else 0, entry[1] or 0, entry[0]))
 
 		# Add panes in the created order

--- a/bones/email.py
+++ b/bones/email.py
@@ -41,7 +41,7 @@ class EmailEditBone( strBone.StringEditBone ):
 			self.input["value"] = data[ self.boneName ] if data[ self.boneName ] else ""
 
 	def serializeForPost(self):
-		if not self["value"] or re.match("^[a-zA-Z0-9._%-+]+@[a-zA-Z0-9._-]+.[a-zA-Z]{2,6}$",self.input["value"]):
+		if not self["value"] or re.match("^[a-zA-Z0-9._%\-+]+@[a-zA-Z0-9._\-]+.[a-zA-Z]{2,6}$",self.input["value"]):
 			return( { self.boneName: self.input["value"] } )
 		raise InvalidBoneValueException()
 

--- a/bones/file.py
+++ b/bones/file.py
@@ -137,18 +137,18 @@ class FileMultiSelectionBoneEntry(RelationalMultiSelectionBoneEntry):
 		"""
 			Edit the image entry.
 		"""
-		pane = Pane(translate("Edit"), closeable=True, iconClasses=[ "modul_%s" % self.parent.destModule,
+		pane = Pane(translate("Edit"), closeable=True, iconClasses=[ "module_%s" % self.relationalBone.destModule,
 		                                                                "apptype_list", "action_edit" ] )
 		conf["mainWindow"].stackPane(pane, focus=True)
 
 		try:
-			edwg = EditWidget(self.parent.destModule, EditWidget.appTree, key=self.data["dest"]["key"], skelType="leaf")
+			edwg = EditWidget(self.relationalBone.destModule, EditWidget.appTree, key=self.data["dest"]["key"], skelType="leaf")
 			pane.addWidget(edwg)
 		except AssertionError:
 			conf["mainWindow"].removePane(pane)
 
 	def update(self):
-		NetworkService.request(self.parent.destModule, "view/leaf",
+		NetworkService.request(self.relationalBone.destModule, "view/leaf",
 		                        params={"key": self.data["dest"]["key"]},
 		                        successHandler=self.onModuleViewAvailable)
 

--- a/bones/relational.py
+++ b/bones/relational.py
@@ -503,7 +503,7 @@ class RelationalMultiSelectionBoneEntry(html5.Div):
 		super(RelationalMultiSelectionBoneEntry, self).__init__(*args, **kwargs)
 		self.sinkEvent("onDrop", "onDragOver", "onDragLeave", "onDragStart", "onDragEnd", "onChange")
 
-		self.parent = parent
+		self.relationalBone = parent
 		self.module = module
 		self.data = data
 
@@ -536,9 +536,9 @@ class RelationalMultiSelectionBoneEntry(html5.Div):
 			self.ie = None
 
 		# Edit button
-		if (self.parent.destModule in conf["modules"].keys()
+		if (self.relationalBone.destModule in conf["modules"].keys()
 			and ("root" in conf["currentUser"]["access"]
-					or self.parent.destModule + "-edit" in conf["currentUser"]["access"])):
+			     or self.relationalBone.destModule + "-edit" in conf["currentUser"]["access"])):
 
 			self.editBtn = html5.ext.Button(translate("Edit"), self.onEdit)
 			self.editBtn["class"].append("icon")
@@ -556,74 +556,74 @@ class RelationalMultiSelectionBoneEntry(html5.Div):
 			data = self.data
 
 		self.txtLbl.removeAllChildren()
-		txt = utils.formatString(self.parent.format, data["dest"], self.parent.relskel,
-		                            prefix=["dest"], language=conf["currentlanguage"])
+		txt = utils.formatString(self.relationalBone.format, data["dest"], self.relationalBone.relskel,
+		                         prefix=["dest"], language=conf["currentlanguage"])
 
 		if self.ie:
-			txt = utils.formatString(txt, self.ie.serializeForDocument(), self.parent.using,
-			                            prefix=["rel"], language=conf["currentlanguage"])
+			txt = utils.formatString(txt, self.ie.serializeForDocument(), self.relationalBone.using,
+			                         prefix=["rel"], language=conf["currentlanguage"])
 
 		html5.utils.textToHtml(self.txtLbl, txt)
 
 	def onDragStart(self, event):
-		if self.parent.readOnly:
+		if self.relationalBone.readOnly:
 			return
 
 		self.addClass("is-dragging")
 
-		self.parent.currentDrag = self
+		self.relationalBone.currentDrag = self
 		event.dataTransfer.setData("application/json", json.dumps(self.data))
 		event.stopPropagation()
 
 	def onDragOver(self, event):
-		if self.parent.readOnly:
+		if self.relationalBone.readOnly:
 			return
 
-		if self.parent.currentDrag is not self:
+		if self.relationalBone.currentDrag is not self:
 			self.addClass("is-dragging-over")
-			self.parent.currentOver = self
+			self.relationalBone.currentOver = self
 
 		event.preventDefault()
 
 	def onDragLeave(self, event):
-		if self.parent.readOnly:
+		if self.relationalBone.readOnly:
 			return
 
 		self.removeClass("is-dragging-over")
-		self.parent.currentOver = None
+		self.relationalBone.currentOver = None
 
 		event.preventDefault()
 
 	def onDragEnd(self, event):
-		if self.parent.readOnly:
+		if self.relationalBone.readOnly:
 			return
 
 		self.removeClass("is-dragging")
-		self.parent.currentDrag = None
+		self.relationalBone.currentDrag = None
 
-		if self.parent.currentOver:
-			self.parent.currentOver.removeClass("is-dragging-over")
-			self.parent.currentOver = None
+		if self.relationalBone.currentOver:
+			self.relationalBone.currentOver.removeClass("is-dragging-over")
+			self.relationalBone.currentOver = None
 
 		event.stopPropagation()
 
 	def onDrop(self, event):
-		if self.parent.readOnly:
+		if self.relationalBone.readOnly:
 			return
 
 		event.preventDefault()
 		event.stopPropagation()
 
-		if self.parent.currentDrag and self.parent.currentDrag != self:
-			if self.element.offsetTop > self.parent.currentDrag.element.offsetTop:
-				if self.parent.entries[-1] is self:
-					self.parent.moveEntry(self.parent.currentDrag)
+		if self.relationalBone.currentDrag and self.relationalBone.currentDrag != self:
+			if self.element.offsetTop > self.relationalBone.currentDrag.element.offsetTop:
+				if self.relationalBone.entries[-1] is self:
+					self.relationalBone.moveEntry(self.relationalBone.currentDrag)
 				else:
-					self.parent.moveEntry(self.parent.currentDrag, self.parent.entries[self.parent.entries.index(self) + 1])
+					self.relationalBone.moveEntry(self.relationalBone.currentDrag, self.relationalBone.entries[self.relationalBone.entries.index(self) + 1])
 			else:
-				self.parent.moveEntry(self.parent.currentDrag, self)
+				self.relationalBone.moveEntry(self.relationalBone.currentDrag, self)
 
-		self.parent.currentDrag = None
+		self.relationalBone.currentDrag = None
 
 	def onChange(self, event):
 		data = self.data.copy()
@@ -632,17 +632,17 @@ class RelationalMultiSelectionBoneEntry(html5.Div):
 		self.updateLabel(data)
 
 	def onRemove(self, *args, **kwargs):
-		self.parent.removeEntry(self)
-		self.parent.changeEvent.fire(self.parent)
+		self.relationalBone.removeEntry(self)
+		self.relationalBone.changeEvent.fire(self.relationalBone)
 
 	def onEdit(self, sender = None):
 		pane = Pane(translate("Edit"), closeable=True,
-					iconClasses=["module_%s" % self.parent.destModule, "apptype_list", "action_edit"])
+		            iconClasses=["module_%s" % self.relationalBone.destModule, "apptype_list", "action_edit"])
 		conf["mainWindow"].stackPane(pane, focus=True)
 
 		try:
-			edwg = EditWidget(self.parent.destModule, EditWidget.appList, key=self.data["dest"]["key"],
-			                    context=self.parent.context)
+			edwg = EditWidget(self.relationalBone.destModule, EditWidget.appList, key=self.data["dest"]["key"],
+			                  context=self.relationalBone.context)
 			pane.addWidget(edwg)
 
 		except AssertionError:
@@ -669,20 +669,23 @@ class RelationalMultiSelectionBoneEntry(html5.Div):
 		super(RelationalMultiSelectionBoneEntry, self).onAttach()
 		NetworkService.registerChangeListener(self)
 
+		if self.relationalBone["disabled"]:
+			self.disable()
+
 	def onDetach(self):
 		NetworkService.removeChangeListener(self)
 		super(RelationalMultiSelectionBoneEntry, self).onDetach()
 
 	def onDataChanged(self, module, key = None, **kwargs):
-		if module != self.parent.destModule or key != self.data["dest"]["key"]:
+		if module != self.relationalBone.destModule or key != self.data["dest"]["key"]:
 			return
 
 		self.update()
 
 	def update(self):
-		NetworkService.request(self.parent.destModule, "view",
-		                        params={"key": self.data["dest"]["key"]},
-		                        successHandler=self.onModuleViewAvailable)
+		NetworkService.request(self.relationalBone.destModule, "view",
+		                       params={"key": self.data["dest"]["key"]},
+		                       successHandler=self.onModuleViewAvailable)
 
 	def onModuleViewAvailable(self, req):
 		answ = NetworkService.decode(req)

--- a/bones/relational.py
+++ b/bones/relational.py
@@ -560,7 +560,7 @@ class RelationalMultiSelectionBoneEntry(html5.Div):
 		                            prefix=["dest"], language=conf["currentlanguage"])
 
 		if self.ie:
-			txt = utils.formatString(txt, self.ie.doSave(), self.parent.using,
+			txt = utils.formatString(txt, self.ie.serializeForDocument(), self.parent.using,
 			                            prefix=["rel"], language=conf["currentlanguage"])
 
 		html5.utils.textToHtml(self.txtLbl, txt)
@@ -660,7 +660,7 @@ class RelationalMultiSelectionBoneEntry(html5.Div):
 		res = {"rel": {}, "dest": {}}
 
 		if self.ie:
-			res["rel"] = self.ie.serializeForPost()
+			res["rel"] = self.ie.serializeForDocument()
 
 		res["dest"]["key"] = self.data["dest"]["key"]
 		return res

--- a/bones/relational.py
+++ b/bones/relational.py
@@ -491,7 +491,7 @@ class RelationalMultiSelectionBoneEntry(html5.Div):
 		Provides the UI to display its data and a button to remove it from the bone.
 	"""
 
-	def __init__(self, parent, module, data, using, errorInfo, *args, **kwargs ):
+	def __init__(self, parent, module, data, using=None, errorInfo=None, *args, **kwargs ):
 		"""
 			:param parent: Reference to the RelationalMultiSelectionBone we belong to
 			:type parent: RelationalMultiSelectionBone

--- a/bones/string.py
+++ b/bones/string.py
@@ -330,10 +330,11 @@ class StringEditBone(html5.Div):
 
 	def unserialize(self, data, extendedErrorInformation=None):
 		data = data.get(self.boneName)
-		if not data:
-			return
 
 		if self.languages and self.multiple:
+			if data is None:
+				data = {}
+
 			assert isinstance(data, dict)
 
 			for lang in self.languages:
@@ -351,6 +352,9 @@ class StringEditBone(html5.Div):
 							self.genTag(html5.utils.unescape(v), lang=lang)
 
 		elif self.languages and not self.multiple:
+			if data is None:
+				data = {}
+
 			assert isinstance(data, dict)
 
 			for lang in self.languages:
@@ -360,6 +364,8 @@ class StringEditBone(html5.Div):
 					self.langEdits[lang]["value"] = ""
 
 		elif not self.languages and self.multiple:
+			if data is None:
+				data = []
 
 			for child in self.tagContainer.children():
 				if isinstance(child, Tag):
@@ -372,6 +378,9 @@ class StringEditBone(html5.Div):
 				self.genTag(html5.utils.unescape(data))
 
 		else:
+			if data is None:
+				data = ""
+
 			self.input["value"] = html5.utils.unescape(str(data))
 
 		self._updateLanguageButtons()

--- a/bones/string.py
+++ b/bones/string.py
@@ -13,28 +13,40 @@ from priorityqueue import \
 
 class StringBoneExtractor(BaseBoneExtractor):
 
-	def render(self, data, field):
-		if field in data.keys():
-			##multilangs
-			if isinstance(data[field], dict):
-				resstr = ""
-				if "currentlanguage" in conf.keys():
-					if conf["currentlanguage"] in data[field].keys():
-						resstr = data[field][conf["currentlanguage"]].replace("&quot;", "'").replace(";", " ").replace(
-							'"', "'")
-					else:
-						if len(data[field].keys()) > 0:
-							resstr = data[field][data[field].keys()[0]].replace("&quot;", "'").replace(";",
-							                                                                           " ").replace('"',
-							                                                                                        "'")
-				return '"%s"' % resstr
-			elif isinstance(data[field], list):
-				return ", ".join(
-					[item.replace("&quot;", "").replace(";", " ").replace('"', "'") for item in data[field]])
-			elif data[field] is not None:
-				return str('"%s"' % str(data[field]).replace("&quot;", "").replace(";", " ").replace('"', "'"))
+	def _unescape(self, val):
+		val = html5.utils.unescape(str(val))
+		return val.replace(";", " ").replace('"', "'")
 
-		return conf["empty_value"]
+	def render(self, data, field):
+		if not data.get(field):
+			return conf["empty_value"]
+
+		if isinstance(data[field], dict):
+			return '"%s"' % self._unescape(data[field].get(conf["currentlanguage"] or data[field].keys()[0]))
+
+		elif isinstance(data[field], list):
+			return ", ".join([self.unescape(item) for item in data[field]])
+
+		return '"%s"' % self._unescape(data[field])
+
+	def raw(self, data, field):
+		if field not in data:
+			return None
+
+		ret = val = data[field]
+		if isinstance(val, dict):
+			ret = []
+
+			for entry in val.values():
+				if not entry:
+					continue
+
+				if isinstance(entry, list):
+					ret.extend(entry)
+				else:
+					ret.append(entry)
+
+		return ret
 
 
 class StringViewBoneDelegate(object):

--- a/bones/text.py
+++ b/bones/text.py
@@ -1,32 +1,14 @@
 # -*- coding: utf-8 -*-
 import html5
-from bones.base import BaseBoneExtractor
+from bones.string import StringBoneExtractor
 from config import conf
 from priorityqueue import editBoneSelector, viewDelegateSelector, extractorDelegateSelector
 from widgets.htmleditor import HtmlEditor
 from event import EventDispatcher
 
 
-class TextBoneExtractor(BaseBoneExtractor):
-
-	def render(self, data, field):
-		if field in data.keys():
-			##multilangs
-			if isinstance(data[field], dict):
-				resstr = ""
-				if "currentlanguage" in conf.keys():
-					if conf["currentlanguage"] in data[field].keys():
-						resstr = data[field][conf["currentlanguage"]].replace("&quot;", "").replace(";", " ").replace(
-							'"', "'")
-					else:
-						if data[field].keys().length > 0:
-							resstr = data[field][data[field].keys()[0]].replace("&quot;", "").replace(";", " ").replace(
-								'"', "'")
-				return '"%s"' % resstr
-			else:
-				# no langobject
-				return str('"%s"' % data[field].replace("&quot;", "").replace(";", " ").replace('"', "'"))
-		return conf["empty_value"]
+class TextBoneExtractor(StringBoneExtractor):
+	pass
 
 
 class TextViewBoneDelegate(object):

--- a/bones/text.py
+++ b/bones/text.py
@@ -105,7 +105,6 @@ class TextEditBone(html5.Div):
 		self.sinkEvent("onKeyUp")
 
 		self.changeEvent = EventDispatcher("boneChange")
-		self._changeTimeout = None
 
 	def _setDisabled(self, disable):
 		"""
@@ -182,13 +181,7 @@ class TextEditBone(html5.Div):
 		pass
 
 	def onKeyUp(self, event):
-		if not self.changeEvent.queue:
-			return
-
-		if self._changeTimeout:
-			html5.window.clearTimeout(self._changeTimeout)
-
-		self._changeTimeout = html5.window.setTimeout(lambda: self.changeEvent.fire(self), 500)
+		self.changeEvent.fire(self)
 
 	@staticmethod
 	def checkForTextBone(moduleName, boneName, skelStucture, *args, **kwargs):

--- a/bones/treedir.py
+++ b/bones/treedir.py
@@ -31,8 +31,9 @@ class TreeDirMultiSelectionBoneEntry(RelationalMultiSelectionBoneEntry):
 			self.element.insertBefore(img.element, self.element.children.item(0))
 
 		#Remove the editbutton. This won't work on directories; but we maybe need this for other modules?!
-		self.removeChild(self.editBtn)
-		self.editBtn = None
+		if self.editBtn:
+			self.editBtn.parent().removeChild(self.editBtn)
+			self.editBtn = None
 
 	def fetchEntry(self, key):
 		NetworkService.request(self.module, "view/node/%s" % key,

--- a/config.py
+++ b/config.py
@@ -70,6 +70,9 @@ conf = {
 	# Globally enable/disable dataset preview in lists
 	"internalPreview": True,
 
+	# Fallback default preview path template (if set None, adminInfo.preview only takes place)
+	"defaultPreview": None,  # "/{{module}}/view/{{key}}"
+
 	# Max number of entries to show in multiple Bones
 	"maxMultiBoneEntries": 5,
 

--- a/config.py
+++ b/config.py
@@ -22,6 +22,9 @@ conf = {
 	# Which access rights are required to open the Vi?
 	"vi.access.rights": ["admin", "root"],
 
+	# Context access variable prefix
+	"vi.context.prefix": "",
+
 	# Global holder to main configuration taken from the server
 	"mainConfig": None,
 

--- a/config.py
+++ b/config.py
@@ -25,6 +25,9 @@ conf = {
 	# Context access variable prefix
 	"vi.context.prefix": "",
 
+	# Context action title fields
+	"vi.context.title.bones": ["name"],
+
 	# Global holder to main configuration taken from the server
 	"mainConfig": None,
 

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ from logics import Interpreter
 
 conf = {
 	# Vi version number
-	"vi.version": (2, 5, 0),
+	"vi.version": (2, 5, 1),
 
 	# Appendix to version
 	"vi.version.appendix": "",

--- a/network.py
+++ b/network.py
@@ -88,7 +88,7 @@ class HTTPRequest(object):
 			else:
 				self.cb.onError( self.req.responseText, self.req.status )
 
-class NetworkService( object ):
+class NetworkService(object):
 	"""
 		Generic wrapper around ajax requests.
 		Handles caching and multiplexing multiple concurrent requests to
@@ -101,7 +101,7 @@ class NetworkService( object ):
 	prefix = "/json"
 	defaultFailureHandler = None
 
-	retryCodes = [0, -1, 500, 502]
+	retryCodes = [0, -1]
 	retryMax = 3
 	retryDelay = 5000
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1257,7 +1257,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
@@ -1294,7 +1294,7 @@
         },
         "lodash": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
         },
         "minimatch": {
@@ -2106,9 +2106,9 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"

--- a/utils.py
+++ b/utils.py
@@ -28,6 +28,14 @@ def formatString(format, data, structure = None, prefix = None, language = None,
 	:rtype: str
 	"""
 
+	#if _rec == 0:
+	#	print("--- formatString ---")
+	#	print(format)
+	#	print(data)
+	#	print(structure)
+	#	print(prefix)
+	#	print(language)
+
 	if structure and isinstance(structure, list):
 		structure = {k:v for k, v in structure}
 
@@ -45,6 +53,9 @@ def formatString(format, data, structure = None, prefix = None, language = None,
 
 	for key in data.keys():
 		val = data[key]
+
+		#if _rec == 0:
+		#	print(key, val)
 
 		# Get structure if available
 		struct = structure.get(key) if structure else None

--- a/widgets/edit.py
+++ b/widgets/edit.py
@@ -882,7 +882,17 @@ class EditWidget(html5.Div):
 
 				if vvariable:
 					context = self.context.copy() if self.context else {}
-					context[vvariable] = data["values"]["key"]
+
+					if "=" in vvariable:
+						vkey, vvalue = vvariable.split("=", 1)
+						if vvalue[0] == "$":
+							vvalue = data["values"].get(vvalue[1:])
+					else:
+						vkey = vvariable
+						vvalue = data["values"].get("key")
+
+					context[vkey] = vvalue
+
 				else:
 					context = self.context
 

--- a/widgets/edit.py
+++ b/widgets/edit.py
@@ -861,6 +861,7 @@ class EditWidget(html5.Div):
 				vtitle = view.get("title")
 				vcolumns = view.get("columns")
 				vfilter = view.get("filter")
+				vactions = view.get("actions")
 
 				if not vmodule:
 					print("Misconfiured view: %s" % view)
@@ -896,9 +897,14 @@ class EditWidget(html5.Div):
 				else:
 					context = self.context
 
-				self.views[vmodule] = ListWidget(vmodule, filter=vfilter or vdescr.get("filter", {}),
-				                                    columns = vcolumns or vdescr.get("columns"),
-				                                    context = context)
+				self.views[vmodule] = ListWidget(
+					vmodule,
+					filter=vfilter or vdescr.get("filter", {}),
+					columns=vcolumns or vdescr.get("columns"),
+					context=context,
+					actions=vactions
+				)
+
 				fs._section.appendChild(self.views[vmodule])
 				self.form.appendChild(fs)
 

--- a/widgets/file.py
+++ b/widgets/file.py
@@ -155,8 +155,15 @@ class Uploader(html5.Progress):
 		self.uploadSuccess = EventDispatcher("uploadSuccess")
 		self.responseValue = None
 		self.context = context
-		# self.files = files
-		r = NetworkService.request("file", "getUploadURL", successHandler=self.onUploadUrlAvailable, secure=True)
+		#self.files = files
+
+		r = NetworkService.request("file", "getUploadURL",
+			params={"node": node} if node else {},
+			successHandler=self.onUploadUrlAvailable,
+			failureHandler=self.onUploadUrlFailure,
+			secure=True
+		)
+
 		r.file = file
 		r.node = node
 		conf["mainWindow"].log("progress", self)
@@ -166,10 +173,13 @@ class Uploader(html5.Progress):
 		"""
 			Internal callback - the actual upload url (retrieved by calling /file/getUploadURL) is known.
 		"""
-		r = NetworkService.request("", "/admin/skey", successHandler=self.onSkeyAvailable)
+		r = NetworkService.request("skey", "", successHandler=self.onSkeyAvailable)
 		r.file = req.file
 		r.node = req.node
 		r.destUrl = req.result
+
+	def onUploadUrlFailure(self, req, code):
+		self.onFailed(code)
 
 	def onSkeyAvailable(self, req):
 		"""

--- a/widgets/file.py
+++ b/widgets/file.py
@@ -291,7 +291,7 @@ class FileWidget(TreeWidget):
 
 	@staticmethod
 	def render(moduleName, adminInfo, context):
-		rootNode = context.get("rootNode") if context else None
+		rootNode = context.get(conf["vi.context.prefix"] + "rootNode") if context else None
 		return FileWidget(module=moduleName, rootNode=rootNode, context=context)
 
 

--- a/widgets/hierarchy.py
+++ b/widgets/hierarchy.py
@@ -512,12 +512,7 @@ class HierarchyWidget(html5.Div):
 
 	@staticmethod
 	def render(moduleName, adminInfo, context):
-		if "@rootNode" in context:
-			rootNode = context["@rootNode"]
-			del context["@rootNode"]
-		else:
-			rootNode = None
-
+		rootNode = context.get(conf["vi.context.prefix"] + "rootNode") if context else None
 		return HierarchyWidget(module=moduleName, rootNode=rootNode, context=context)
 
 moduleHandlerSelector.insert(1, HierarchyWidget.canHandle, HierarchyWidget.render)

--- a/widgets/htmleditor.py
+++ b/widgets/htmleditor.py
@@ -4,7 +4,6 @@ from __pyjamas__ import JS
 from i18n import translate
 from widgets.file import FileWidget
 from config import conf
-from utils import getImagePreview
 
 
 class TextInsertImageAction(html5.ext.Button):
@@ -90,7 +89,7 @@ class HtmlEditor(html5.Textarea):
 		lang = conf["currentlanguage"]
 
 		try:
-			self.summernote = JS("""window.top.summernoteEditor(@{{elem}}, @{{lang}})""")
+			self.summernote = html5.window.top.summernoteEditor(elem, lang)
 		except:
 			if retry >= 3:
 				alert("Unable to connect summernote, please contact technical support...")
@@ -102,8 +101,6 @@ class HtmlEditor(html5.Textarea):
 
 		imagebtn = TextInsertImageAction(summernote=self.summernote, boneName=self.boneName)
 		self.parent().appendChild(imagebtn)
-
-		self.summernote.on("summernote.change", self.onEditorChange)
 
 		if not self.enabled:
 			self.summernote.summernote("disable")
@@ -146,8 +143,10 @@ class HtmlEditor(html5.Textarea):
 			self.value = val
 			return
 
+		self.summernote.off("summernote.change")
 		self.summernote.summernote("reset")  # reset history and content
 		self.summernote.summernote("code", val)
+		self.summernote.on("summernote.change", self.onEditorChange)
 
 	def enable(self):
 		super(HtmlEditor, self).enable()

--- a/widgets/list.py
+++ b/widgets/list.py
@@ -16,8 +16,8 @@ class ListWidget(html5.Div):
 		It acts as a data-provider for a DataTable and binds an action-bar
 		to this table.
 	"""
-	def __init__(self, module, filter=None, columns=None, selectMode = None, filterID=None, filterDescr=None,
-	             batchSize = None, context = None, autoload = True, *args, **kwargs):
+	def __init__(self, module, filter=None, columns=None, selectMode=None, filterID=None, filterDescr=None,
+	             batchSize=None, context=None, autoload=True, actions=None, *args, **kwargs):
 		"""
 			:param module: Name of the module we shall handle. Must be a list application!
 			:type module: str
@@ -93,7 +93,8 @@ class ListWidget(html5.Div):
 		            "getCurrentSelection"]:
 			setattr( self, f, getattr(self.table,f))
 
-		self.actionBar.setActions( self.getDefaultActions( myView ) )
+		assert actions is None or isinstance(actions, list), "actions must be either a list or None!"
+		self.actionBar.setActions(actions or self.getDefaultActions(myView))
 
 		if self.selectMode:
 			self.selectionActivatedEvent.register(self)
@@ -118,7 +119,7 @@ class ListWidget(html5.Div):
 		if self.filterDescr:
 			self.filterDescriptionSpan.appendChild(html5.TextNode(html5.utils.unescape(self.filterDescr)))
 
-	def getDefaultActions(self, view = None ):
+	def getDefaultActions(self, view=None):
 		"""
 			Returns the list of actions available in our actionBar
 		"""

--- a/widgets/tree.py
+++ b/widgets/tree.py
@@ -6,6 +6,8 @@ from widgets.actionbar import ActionBar
 from event import EventDispatcher
 from priorityqueue import displayDelegateSelector, viewDelegateSelector, moduleHandlerSelector
 from config import conf
+from i18n import translate
+
 
 class _StructureWidget(html5.Li):
 
@@ -56,7 +58,7 @@ class _StructureWidget(html5.Li):
 
 			self.appendChild(html5.utils.unescape(
 				utils.formatString(format, self.data, self.structure,
-				    language=conf["currentlanguage"])))
+					language=conf["currentlanguage"])))
 
 class NodeWidget(_StructureWidget):
 	"""
@@ -100,11 +102,23 @@ class NodeWidget(_StructureWidget):
 			return
 
 		NetworkService.request(
-			self.module, "move", {
+			self.module,
+			"move", {
 				"skelType": nodeType,
 				"key": srcKey,
 				"destNode": self.data["key"]
-			}, modifies=True, secure=True)
+			},
+			failureHandler=lambda req, code:
+				conf["mainWindow"].log(
+					"error",
+					translate(
+						"Node cannot be moved, error {code}.",
+						code=code
+					)
+				),
+			modifies=True,
+			secure=True
+		)
 
 		event.preventDefault()
 		event.stopPropagation()
@@ -280,7 +294,7 @@ class TreeWidget(html5.Div):
 	leafWidget = LeafWidget
 	defaultActions = ["add.node", "add.leaf", "selectrootnode", "edit", "delete", "reload"]
 
-	def __init__(self, module, rootNode=None, node=None, selectMode=None, *args, **kwargs):
+	def __init__(self, module, rootNode=None, node=None, selectMode=None, context=None, *args, **kwargs):
 		"""
 			:param module: Name of the module we shall handle. Must be a list application!
 			:type module: str
@@ -294,6 +308,7 @@ class TreeWidget(html5.Div):
 
 		self.module = module
 		self.rootNode = rootNode
+		self.context = context
 		self.node = node or rootNode
 		self.actionBar = ActionBar(module, "tree")
 		self.appendChild(self.actionBar)

--- a/widgets/tree.py
+++ b/widgets/tree.py
@@ -528,7 +528,7 @@ class TreeWidget(html5.Div):
 
 	@staticmethod
 	def render(moduleName, adminInfo, context):
-		rootNode = context.get("@rootNode") if context else None
+		rootNode = context.get(conf["vi.context.prefix"] + "rootNode") if context else None
 		return TreeWidget(module=moduleName, rootNode=rootNode, context=context)
 
 

--- a/widgets/tree.py
+++ b/widgets/tree.py
@@ -62,10 +62,11 @@ class NodeWidget(_StructureWidget):
 	"""
 		Displays one Node (ie a directory) inside a TreeWidget
 	"""
+	skelType =  "node"
 
 	def __init__(self, module, data, structure, *args, **kwargs):
 		super(NodeWidget, self).__init__(module, data, structure, *args, **kwargs)
-		self.addClass("treeitem", "node", "supports_drag", "supports_drop")
+		self.addClass("treeitem", self.skelType, "supports_drag", "supports_drop")
 		self.sinkEvent("onDragOver", "onDrop", "onDragStart", "onDragLeave")
 
 	def onDragOver(self, event):
@@ -113,6 +114,7 @@ class LeafWidget(_StructureWidget):
 	"""
 		Displays one Node (ie a file) inside a TreeWidget
 	"""
+	skelType = "leaf"
 
 	def __init__(self, module, data, structure, *args, **kwargs):
 		"""
@@ -123,9 +125,8 @@ class LeafWidget(_StructureWidget):
 			:param structure: The structure of that data as received from server
 			:type structure: list
 		"""
-		super(LeafWidget, self).__init__( module, data, structure, *args, **kwargs)
-
-		self.addClass("treeitem", "leaf", "supports_drag")
+		super(LeafWidget, self).__init__(module, data, structure, *args, **kwargs)
+		self.addClass("treeitem", self.skelType, "supports_drag")
 		self.sinkEvent("onDragStart")
 
 	def onDragStart(self, event):
@@ -196,10 +197,7 @@ class SelectionContainer(html5.Ul):
 		for child in self.children():
 
 			if html5.utils.doesEventHitWidgetOrChildren(event, child):
-				if self.selectionType == "node" and isinstance(child, self.nodeWidget) or \
-					self.selectionType == "leaf" and isinstance(child, self.leafWidget) or \
-					self.selectionType == "both":
-
+				if self.selectionType == "both" or self.selectionType == child.skelType:
 					self.selectionActivatedEvent.fire(self, [child])
 					break
 
@@ -378,10 +376,10 @@ class TreeWidget(html5.Div):
 
 		item = selection[0]
 
-		if isinstance(item, self.nodeWidget):
+		if item.skelType == "node":
 			self.setNode(item.data["key"])
 
-		elif isinstance(item, self.leafWidget) and "leaf" in (self.selectMode or ""):
+		elif item.skelType == "leaf" and "leaf" in (self.selectMode or ""):
 			self.returnCurrentSelection()
 
 	def activateCurrentSelection(self):

--- a/widgets/tree.py
+++ b/widgets/tree.py
@@ -410,7 +410,7 @@ class TreeWidget(html5.Div):
 
 	def setRootNode(self, rootNode, node=None):
 		self.rootNode = rootNode
-		self.node = node if node else rootNode
+		self.node = node or rootNode
 		self.rootNodeChangedEvent.fire(rootNode)
 		if node:
 			self.nodeChangedEvent.fire(node)
@@ -530,7 +530,7 @@ class TreeWidget(html5.Div):
 
 	@staticmethod
 	def render(moduleName, adminInfo, context):
-		rootNode = context.get("rootNode") if context else None
+		rootNode = context.get("@rootNode") if context else None
 		return TreeWidget(module=moduleName, rootNode=rootNode, context=context)
 
 

--- a/widgets/tree.py
+++ b/widgets/tree.py
@@ -297,7 +297,7 @@ class TreeWidget(html5.Div):
 		self.node = node or rootNode
 		self.actionBar = ActionBar(module, "tree")
 		self.appendChild(self.actionBar)
-		self.pathList = html5.Div()
+		self.pathList = html5.Ul()
 		self.pathList["class"].append("breadcrumb")
 		self.appendChild(self.pathList)
 		self.entryFrame = SelectionContainer(self.nodeWidget, self.leafWidget)
@@ -436,7 +436,7 @@ class TreeWidget(html5.Div):
 		skel = answ["values"]
 
 		if skel["parentdir"] and skel["parentdir"] != skel["key"]:
-			c = NodeWidget(self.module, skel, [])
+			c = self.nodeWidget(self.module, skel, answ["structure"])
 
 			NetworkService.request(
 				self.module, "view/node/%s" % skel["parentdir"],
@@ -444,7 +444,7 @@ class TreeWidget(html5.Div):
 			)
 
 		else:
-			c = NodeWidget(self.module, {"key": self.rootNode, "name": "root"}, [])
+			c = self.nodeWidget(self.module, {"key": self.rootNode, "name": "root"}, [])
 			c.addClass("is_rootnode")
 
 		self.pathList.prependChild(c)

--- a/widgets/tree.py
+++ b/widgets/tree.py
@@ -1,17 +1,13 @@
 # -*- coding: utf-8 -*-
-import html5
+import html5, utils
+
 from network import NetworkService
 from widgets.actionbar import ActionBar
 from event import EventDispatcher
 from priorityqueue import displayDelegateSelector, viewDelegateSelector, moduleHandlerSelector
 from config import conf
 
-
-
-class NodeWidget(html5.Div):
-	"""
-		Displays one Node (ie a directory) inside a TreeWidget
-	"""
+class _StructureWidget(html5.Li):
 
 	def __init__(self, module, data, structure, *args, **kwargs):
 		"""
@@ -22,34 +18,55 @@ class NodeWidget(html5.Div):
 			:param structure: The structure of that data as received from server
 			:type structure: list
 		"""
-		super(NodeWidget, self).__init__(*args, **kwargs)
+		super(_StructureWidget, self).__init__()
+
 		self.module = module
 		self.data = data
 		self.structure = structure
-		self.buildDescription()
-		self.addClass("treeitem", "node", "supports_drag", "supports_drop")
-		self["draggable"] = True
 
-		self.sinkEvent("onDragOver", "onDrop", "onDragStart", "onDragLeave")
+		self.buildDescription()
+		self["draggable"] = True
 
 	def buildDescription(self):
 		"""
 			Creates the visual representation of our entry
 		"""
+		# Find any bones in the structure having "frontend_default_visible" set.
 		hasDescr = False
+
 		for boneName, boneInfo in self.structure:
 			if "params" in boneInfo.keys() and isinstance(boneInfo["params"], dict):
 				params = boneInfo["params"]
-				if "frontend_default_visible" in params.keys() and params["frontend_default_visible"]:
-
+				if "frontend_default_visible" in params and params["frontend_default_visible"]:
 					structure = {k: v for k, v in self.structure}
 					wdg = viewDelegateSelector.select(self.module, boneName, structure)
 
 					if wdg is not None:
 						self.appendChild(wdg(self.module, boneName, structure).render(self.data, boneName))
 						hasDescr = True
+
+		# In case there is no bone configured for visualization, use a format-string
 		if not hasDescr:
-			self.appendChild(html5.TextNode(self.data["name"]))
+			format = "$(name)" #default fallback
+
+			if self.module in conf["modules"].keys():
+				moduleInfo = conf["modules"][self.module]
+				if "format" in moduleInfo.keys():
+					format = moduleInfo["format"]
+
+			self.appendChild(html5.utils.unescape(
+				utils.formatString(format, self.data, self.structure,
+				    language=conf["currentlanguage"])))
+
+class NodeWidget(_StructureWidget):
+	"""
+		Displays one Node (ie a directory) inside a TreeWidget
+	"""
+
+	def __init__(self, module, data, structure, *args, **kwargs):
+		super(NodeWidget, self).__init__(module, data, structure, *args, **kwargs)
+		self.addClass("treeitem", "node", "supports_drag", "supports_drop")
+		self.sinkEvent("onDragOver", "onDrop", "onDragStart", "onDragLeave")
 
 	def onDragOver(self, event):
 		"""
@@ -92,7 +109,7 @@ class NodeWidget(html5.Div):
 		event.stopPropagation()
 
 
-class LeafWidget(html5.Div):
+class LeafWidget(_StructureWidget):
 	"""
 		Displays one Node (ie a file) inside a TreeWidget
 	"""
@@ -106,34 +123,10 @@ class LeafWidget(html5.Div):
 			:param structure: The structure of that data as received from server
 			:type structure: list
 		"""
-		super(LeafWidget, self).__init__(*args, **kwargs)
-		self.module = module
-		self.data = data
-		self.structure = structure
-		self.buildDescription()
-		self["class"] = "treeitem leaf supports_drag"
-		self["draggable"] = True
+		super(LeafWidget, self).__init__( module, data, structure, *args, **kwargs)
+
+		self.addClass("treeitem", "leaf", "supports_drag")
 		self.sinkEvent("onDragStart")
-
-	def buildDescription(self):
-		"""
-			Creates the visual representation of our entry
-		"""
-		hasDescr = False
-		for boneName, boneInfo in self.structure:
-			if "params" in boneInfo.keys() and isinstance(boneInfo["params"], dict):
-				params = boneInfo["params"]
-				if "frontend_default_visible" in params.keys() and params["frontend_default_visible"]:
-
-					structure = {k: v for k, v in self.structure}
-					wdg = viewDelegateSelector.select(self.module, boneName, structure)
-
-					if wdg is not None:
-						self.appendChild(wdg(self.module, boneName, structure).render(self.data, boneName))
-						hasDescr = True
-
-		if not hasDescr:
-			self.appendChild(html5.TextNode(self.data["name"]))
 
 	def onDragStart(self, event):
 		"""
@@ -143,7 +136,7 @@ class LeafWidget(html5.Div):
 		event.stopPropagation()
 
 
-class SelectableDiv(html5.Div):
+class SelectionContainer(html5.Ul):
 	"""
 		Provides a Container, which allows selecting its contents.
 		Designed to be used within a tree widget, as it distinguishes between
@@ -152,7 +145,7 @@ class SelectableDiv(html5.Div):
 	"""
 
 	def __init__(self, nodeWidget, leafWidget, selectionType="both", multiSelection=False, *args, **kwargs):
-		super(SelectableDiv, self).__init__(*args, **kwargs)
+		super(SelectionContainer, self).__init__(*args, **kwargs)
 		self["class"].append("selectioncontainer")
 		self["tabindex"] = 1
 		self.selectionType = selectionType
@@ -200,12 +193,15 @@ class SelectableDiv(html5.Div):
 			self.selectionChangedEvent.fire(self, [])
 
 	def onDblClick(self, event):
-		for child in self._children:
+		for child in self.children():
+
 			if html5.utils.doesEventHitWidgetOrChildren(event, child):
 				if self.selectionType == "node" and isinstance(child, self.nodeWidget) or \
 					self.selectionType == "leaf" and isinstance(child, self.leafWidget) or \
 					self.selectionType == "both":
+
 					self.selectionActivatedEvent.fire(self, [child])
+					break
 
 	def activateCurrentSelection(self):
 		"""
@@ -306,7 +302,7 @@ class TreeWidget(html5.Div):
 		self.pathList = html5.Div()
 		self.pathList["class"].append("breadcrumb")
 		self.appendChild(self.pathList)
-		self.entryFrame = SelectableDiv(self.nodeWidget, self.leafWidget)
+		self.entryFrame = SelectionContainer(self.nodeWidget, self.leafWidget)
 		self.appendChild(self.entryFrame)
 		self.entryFrame.selectionActivatedEvent.register(self)
 		self._batchSize = 99
@@ -488,6 +484,7 @@ class TreeWidget(html5.Div):
 
 		self._currentRequests.remove(req)
 		data = NetworkService.decode(req)
+
 		for skel in data["skellist"]:
 			if req.reqType == "node":
 				n = self.nodeWidget(self.module, skel, data["structure"])
@@ -495,7 +492,8 @@ class TreeWidget(html5.Div):
 				n = self.leafWidget(self.module, skel, data["structure"])
 
 			self.entryFrame.appendChild(n)
-			self.entryFrame.sortChildren(self.getChildKey)
+
+		self.entryFrame.sortChildren(self.getChildKey)
 
 		if "cursor" in data.keys() and len(data["skellist"]) == req.params["amount"]:
 			self._currentCursor[req.reqType] = data["cursor"]


### PR DESCRIPTION
Hi there,

I think the following count of features is it worth to be pushed into master. We're currently heading against active development of the Pyodide-based [feature/viur3](https://github.com/viur-framework/viur-vi/tree/feature/viur3) branch.

- Feature: New "action" parameter supported in "editViews" feature
- Feature: Allow to parametrize context variable prefixes using `conf["vi.context.prefix"]`
- Feature: Handle `frontend_default_visible`-parameter for bones also in Hierarchy handler
- Feature: Improved structuring of `NodeWidget` and `LeafWidget` for trees
- Feature: Allow for multiple uploads in File.upload action
- Feature: Added `conf["defaultPreview"]` to set a default preview path as fallback for List-modules
- Bugfix: `ListInternalPreviewAction` always showed up as disabled button with no function
- Bugfix: Tree `edit`-action should not both edit and switch parent node
- Bugfix: Escaped dash in regex for validation of `emailBone`
- Bugfix: `treeDirBone` fixed