### PR TITLE
Fix for latest Chrome and Safari versions

### DIFF
--- a/public/vi.less
+++ b/public/vi.less
@@ -1238,7 +1238,6 @@ form {
 form fieldset {
   width: 100%;
   float: left;
-  overflow: hidden;
   color: #333;
   border: 0;
   padding: 0;


### PR DESCRIPTION
Removed breaking overflow: hidden; in vi.less form fieldset.