### PR TITLE
Use pwd in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 deploy:
-	python3 vi/flare/scripts/flare.py -s ../../sources/viur-vi/vi -t ../../deploy/vi
+	python3 vi/flare/scripts/flare.py -s `pwd`/vi -t ../../deploy/vi
+


### PR DESCRIPTION
Pass better path of current working dir to flare-script, so the vi-submodule-folder can also be named "vi"