### PR TITLE
added back style options to 6_viur_htmleditor.js

### DIFF
--- a/sources/htmleditor/6_viur_htmleditor.js
+++ b/sources/htmleditor/6_viur_htmleditor.js
@@ -118,7 +118,7 @@ function summernoteEditor(input, lang) {
 				'CMD+K': 'linkDialog.show'
 			}
 		},
-		styleTags: ['p', 'h1'], //, 'h2', 'h3', 'h4', 'h5', 'h6'
+		styleTags: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
 		focus: false,
 		dialogsInBody: true,
 		disableDragAndDrop: true,


### PR DESCRIPTION
added back missing styles that customers use when editing their content (h2 - h6). Maybe there was a reason for why this was commented out? can't find anything in the commit history or the changelog though.