### PR TITLE
Load server-side actions from main level if the are not (re)defined on the view

### DIFF
--- a/vi/framework/components/actionbar.py
+++ b/vi/framework/components/actionbar.py
@@ -65,8 +65,21 @@ class ActionBar(html5.Div):
 				else:  # We may have a server-defined action
 					mod = conf["modules"][self.module]
 					if view:
-						mod = view
+						# First, check if that serverside action is defined on view level which takes precedence
+						if handler and "customActions" in view:
+							if action in view["customActions"]:
+								if "access" in view["customActions"][action]:
+									if set(conf["currentUser"]["access"]).isdisjoint(
+											view["customActions"][action]["access"]):
+										continue
 
+								actionWdg = ServerSideActionWdg(self.module, handler, action,
+																view["customActions"][action])
+								self.appendChild(actionWdg)
+								self.widgets[action] = actionWdg
+								continue
+
+					# Second, check if that serverside action is defined on the top level
 					if handler and "customActions" in mod:
 						if action in mod["customActions"]:
 							if "access" in mod["customActions"][action]:


### PR DESCRIPTION
With the current approach, a server-side action has to be re-defined on each view that's going to use it. This patch makes the vi also check the main level of that module for a action if it's not defined on the view itself.